### PR TITLE
desired-capabilities-without-host-and-port

### DIFF
--- a/contesto/basis/driver_mixin.py
+++ b/contesto/basis/driver_mixin.py
@@ -47,8 +47,12 @@ class HttpDriver(AbstractDriver):
             desired_capabilities = cls.capabilities_map[driver_settings["browser"].lower()]
         except KeyError:
             raise UnknownBrowserName(driver_settings.selenium["browser"], cls.capabilities_map.keys())
-        for key in driver_settings:
-            desired_capabilities[key] = driver_settings[key]
+
+        for key, value in driver_settings.iteritems():
+        ### todo IEDriver becomes insane with host/port parameters in desired_capabilities, need investigation
+            if key not in ('host', 'port'):
+                desired_capabilities[key] = value
+
         return desired_capabilities
 
 

--- a/contesto/config/config.default.ini
+++ b/contesto/config/config.default.ini
@@ -2,4 +2,5 @@
 host: localhost
 port: 4444
 browser: firefox
+version: ''
 platform: ANY

--- a/tests/desired_capabilities_tests.py
+++ b/tests/desired_capabilities_tests.py
@@ -23,7 +23,8 @@ class DesireCapabilitiesTestCase(unittest.TestCase):
         driver = HttpDriver()
         driver_settings = getattr(config, driver._driver_type)
         desired_capabilities = driver._form_desired_capabilities(driver_settings)
-        self.assertEqual(desired_capabilities["browser"], "firefox", 'wrong browser in capabilities in httpdriver')
+        self.assertEqual(desired_capabilities["browserName"], "firefox", 'wrong browser in capabilities in httpdriver')
+        self.assertEqual(desired_capabilities["version"], "", 'wrong version in capabilities in httpdriver')
         self.assertEqual(desired_capabilities["platform"], "ANY", 'wrong platform in capabilities in httpdriver')
 
     def test_qtwebkit_driver(self):


### PR DESCRIPTION
Если в desired_capabilities передаем "host" из конфигов, отличный от localhost, то IE-драйверу сносит башку, остальные проглатывают.
И в desired_capabilities вообще не надо передавать никакие host, port.
Убрал в общем и починилось всё. + на всякий случай добавил в конфиг version.
