### PR TITLE
Remove new style setup methods

### DIFF
--- a/contesto/basis/test_case.py
+++ b/contesto/basis/test_case.py
@@ -132,21 +132,5 @@ class ContestoTestCase(unittest.TestCase):
     def tearDown(self):
         self._teardown_test()
 
-    @classmethod
-    def setup_class(cls):
-        cls._setup_class()
-
-    @classmethod
-    def teardown_class(cls):
-        cls._teardown_class()
-
-    def setup_method(self, method):
-        self._setup_test()
-
-    def teardown_method(self, method):
-        self._teardown_test()
-
-# for backward compatibility
 UnittestContestoTestCase = ContestoTestCase
-PyTestContestoTestCase = ContestoTestCase
 BaseTestCase = ContestoTestCase


### PR DESCRIPTION
Running test in classes with both unittest.TestCase and new style setup  methods will result in incorrect initialization. Depending on test runner setup methods will be called twice, or one of the setup methods will be skipped.
Removing new style setup methods fixes this problem, as most test runners support unittest.TestCase style ones.