### PR TITLE
Update dependency version: selenium: from 2.44.0 to 2.45.0 for better python3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup_args = {
     },
     "version": "0.2.0",
     "install_requires": [
-        "selenium==2.44.0",
+        "selenium==2.45.0",
         "Appium-Python-Client==0.17",
         "browsermob-proxy==0.7.1"
     ],


### PR DESCRIPTION
We need [this fix](https://github.com/SeleniumHQ/selenium/commit/67ff2b8b254974446bbb11b6b195c2dbfb4cbdc8) from selenium 2.45.0:
>  if remote end returns a 400 level response status code, for python3 we need to decode the string so it doesn't fail later on when creating the exception to raise


