### PR TITLE
Remove unnecessary creation of ContestoWebElement instance

### DIFF
--- a/contesto/core/driver.py
+++ b/contesto/core/driver.py
@@ -116,7 +116,7 @@ class ContestoWebDriver(Driver, SeleniumDriver):
         except TimeoutException:
             raise ElementNotFound(sizzle_selector, "sizzle selector", driver=self)
 
-        return ContestoWebElement(elements[0])
+        return elements[0]
 
     def find_elements_by_sizzle(self, sizzle_selector):
         """
@@ -133,7 +133,7 @@ class ContestoWebDriver(Driver, SeleniumDriver):
         except TimeoutException:
             raise ElementNotFound(sizzle_selector, "sizzle selector", driver=self)
 
-        return [ContestoWebElement(element) for element in elements]
+        return elements
 
     def _inject_sizzle(self):
         """

--- a/contesto/core/element.py
+++ b/contesto/core/element.py
@@ -42,7 +42,7 @@ class ContestoWebElement(SeleniumWebElement):
         except TimeoutException:
             raise ElementNotFound(sizzle_selector, "sizzle selector", driver=self.parent)
 
-        return ContestoWebElement(elements[0])
+        return elements[0]
 
     def find_elements_by_sizzle(self, sizzle_selector):
         """
@@ -59,7 +59,7 @@ class ContestoWebElement(SeleniumWebElement):
         except TimeoutException:
             raise ElementNotFound(sizzle_selector, "sizzle selector", driver=self.parent)
 
-        return [ContestoWebElement(element) for element in elements]
+        return elements
 
     def _inject_sizzle(self):
         """


### PR DESCRIPTION
Удалил лишнее создание иннстансов ContestoWebElement, т.к. в elements уже хранятся инстансы ContestoWebElement, которые создаются в create_web_element.