### PR TITLE
Don't use object when it not needed

### DIFF
--- a/contesto/utils/log.py
+++ b/contesto/utils/log.py
@@ -8,7 +8,7 @@ class SessionLogger(object):
         logger = logging.getLogger(__name__)
         for frame in inspect.stack()[1:]:
             test = frame[0].f_locals.get("self")
-            if test and hasattr(test, "driver"):
+            if hasattr(test, "driver"):
                 try:
                     logger = logging.getLogger(str(test.driver.session_id))
                 except AttributeError:


### PR DESCRIPTION
Немного упростил проверку. hasattr вернёт False даже если test=None, но если test будет генератором, то получим ```generator already executing```